### PR TITLE
(#18) Unpark fix 

### DIFF
--- a/egregoria/src/map_interaction/itinerary.rs
+++ b/egregoria/src/map_interaction/itinerary.rs
@@ -10,9 +10,9 @@ use specs::Component;
 
 #[derive(Component, Debug, Default, Inspect, Serialize, Deserialize)]
 pub struct Itinerary {
-    kind: ItineraryKind,
+    pub kind: ItineraryKind,
     #[inspect(proxy_type = "InspectVec<Vec2>")]
-    local_path: Vec<Vec2>,
+    pub local_path: Vec<Vec2>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/egregoria/src/map_interaction/itinerary.rs
+++ b/egregoria/src/map_interaction/itinerary.rs
@@ -10,9 +10,9 @@ use specs::Component;
 
 #[derive(Component, Debug, Default, Inspect, Serialize, Deserialize)]
 pub struct Itinerary {
-    pub kind: ItineraryKind,
+    kind: ItineraryKind,
     #[inspect(proxy_type = "InspectVec<Vec2>")]
-    pub local_path: Vec<Vec2>,
+    local_path: Vec<Vec2>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -207,6 +207,13 @@ impl Itinerary {
 
     pub fn local_path(&self) -> &[Vec2] {
         &self.local_path
+    }
+
+    /// Does a logical prepend for a series of points to the local path vector.
+    /// If local is sorted soon to later, then it is also a physical prepend.
+    /// Otherwise it would actually be an append.
+    pub fn prepend_local_path(&mut self, points: Vec<Vec2>) {
+        self.local_path.splice(0..0, points.into_iter());
     }
 
     pub fn has_ended(&self, time: f64) -> bool {

--- a/egregoria/src/vehicles/data.rs
+++ b/egregoria/src/vehicles/data.rs
@@ -15,7 +15,7 @@ use specs::{Builder, Entity, World, WorldExt};
 use specs::{Component, DenseVecStorage};
 
 /// How close a vehicle should be to the start of its itinerary before it decides it's good enough and starts driving.
-pub const DISTANCE_FOR_UNPARKING: f32 = 5.0;
+pub const DISTANCE2_FOR_UNPARKING: f32 = 5.0;
 
 /// The duration for the parking animation.
 pub const TIME_TO_PARK: f32 = 4.0;

--- a/egregoria/src/vehicles/data.rs
+++ b/egregoria/src/vehicles/data.rs
@@ -23,7 +23,7 @@ pub const TIME_TO_PARK: f32 = 4.0;
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum VehicleState {
     Parked(ParkingSpotID),
-    ParkedToRoad(Spline),
+    ParkedToRoad,
     Driving,
     RoadToPark(Spline, f32),
 }

--- a/egregoria/src/vehicles/data.rs
+++ b/egregoria/src/vehicles/data.rs
@@ -14,10 +14,10 @@ use serde::{Deserialize, Serialize};
 use specs::{Builder, Entity, World, WorldExt};
 use specs::{Component, DenseVecStorage};
 
-// How close a vehicle should be to the start of its itinerary before it decides it's good enough and starts driving.
+/// How close a vehicle should be to the start of its itinerary before it decides it's good enough and starts driving.
 pub const DISTANCE_FOR_UNPARKING: f32 = 5.0;
 
-// The duration for the parking animation.
+/// The duration for the parking animation.
 pub const TIME_TO_PARK: f32 = 4.0;
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]

--- a/egregoria/src/vehicles/data.rs
+++ b/egregoria/src/vehicles/data.rs
@@ -14,12 +14,16 @@ use serde::{Deserialize, Serialize};
 use specs::{Builder, Entity, World, WorldExt};
 use specs::{Component, DenseVecStorage};
 
-pub const TIME_TO_PARK: f32 = 5.0;
+// How close a vehicle should be to the start of its itinerary before it decides it's good enough and starts driving.
+pub const DISTANCE_FOR_UNPARKING: f32 = 5.0;
+
+// The duration for the parking animation.
+pub const TIME_TO_PARK: f32 = 4.0;
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
 pub enum VehicleState {
     Parked(ParkingSpotID),
-    ParkedToRoad(Spline, f32),
+    ParkedToRoad(Spline),
     Driving,
     RoadToPark(Spline, f32),
 }

--- a/egregoria/src/vehicles/systems.rs
+++ b/egregoria/src/vehicles/systems.rs
@@ -121,7 +121,8 @@ fn state_update(
             Check the distance to the first traverseable, i.e. the start of the path, and if we're
             close enough then exit unparking mode.
             */
-            let target = it.get_travers()
+            let target = it
+                .get_travers()
                 .expect("Should have a traverse when unparking")
                 .points(map);
             let distance = target.project_len(trans.position());
@@ -207,7 +208,7 @@ fn state_update(
                     new_points.append(&mut itin.local_path.clone());
                     let itin = Itinerary {
                         kind: itin.kind,
-                        local_path: new_points
+                        local_path: new_points,
                     };
 
                     let h = Collider(cow.lock().unwrap().insert(
@@ -260,7 +261,7 @@ fn physics(
             trans.set_position(spline.get(t));
             trans.set_direction(spline.derivative(t).normalize());
             return;
-        },
+        }
         VehicleState::ParkedToRoad(_) => {}
         VehicleState::Driving => {}
     }

--- a/egregoria/src/vehicles/systems.rs
+++ b/egregoria/src/vehicles/systems.rs
@@ -3,7 +3,7 @@ use crate::map_interaction::{Itinerary, ParkingManagement, OBJECTIVE_OK_DIST};
 use crate::physics::{Collider, CollisionWorld, PhysicsGroup, PhysicsObject};
 use crate::physics::{Kinematics, Transform};
 use crate::utils::Restrict;
-use crate::vehicles::{VehicleComponent, VehicleState, DISTANCE_FOR_UNPARKING, TIME_TO_PARK};
+use crate::vehicles::{VehicleComponent, VehicleState, DISTANCE2_FOR_UNPARKING, TIME_TO_PARK};
 use geom::intersections::{both_dist_to_inter, Ray};
 use geom::splines::Spline;
 use geom::{angle_lerp, Vec2};
@@ -123,9 +123,9 @@ fn state_update(
                 .get_travers()
                 .expect("Should have a traverse when unparking")
                 .points(map);
-            let distance = target.project_len2(trans.position());
+            let distance = target.project_dist2(trans.position());
 
-            if distance < DISTANCE_FOR_UNPARKING {
+            if distance < DISTANCE2_FOR_UNPARKING {
                 vehicle.state = VehicleState::Driving;
             }
         }

--- a/egregoria/src/vehicles/systems.rs
+++ b/egregoria/src/vehicles/systems.rs
@@ -116,7 +116,12 @@ fn state_update(
         VehicleState::ParkedToRoad(_, ref mut t) => {
             *t += time.delta / TIME_TO_PARK;
 
-            if *t >= 1.0 {
+            let target = it.get_travers()
+                .expect("Should have a traverse when unparking")
+                .points(map);
+            let distance = target.project_len(trans.position());
+
+            if distance < 5.0 {
                 kin.velocity = trans.direction() * 2.0;
 
                 vehicle.state = VehicleState::Driving;
@@ -299,6 +304,9 @@ fn next_objective(
     .map(move |it| (it, spot_id))
 }
 
+/**
+Decide the appropriate velocity and direction to aim for.
+**/
 pub fn calc_decision<'a>(
     vehicle: &mut VehicleComponent,
     map: &Map,

--- a/egregoria/src/vehicles/systems.rs
+++ b/egregoria/src/vehicles/systems.rs
@@ -117,10 +117,8 @@ fn state_update(
 ) {
     match vehicle.state {
         VehicleState::ParkedToRoad(_) => {
-            /*
-            Check the distance to the first traverseable, i.e. the start of the path, and if we're
-            close enough then exit unparking mode.
-            */
+            /* Check the distance to the first traverseable, i.e. the start of the path, and if we're
+            close enough then exit unparking mode. */
             let target = it
                 .get_travers()
                 .expect("Should have a traverse when unparking")
@@ -128,15 +126,11 @@ fn state_update(
             let distance = target.project_len(trans.position());
 
             if distance < DISTANCE_FOR_UNPARKING {
-                // kin.velocity = trans.direction() * 2.0;
-
                 vehicle.state = VehicleState::Driving;
             }
         }
         VehicleState::RoadToPark(_, ref mut t) => {
-            /*
-            Vehicle is on rails when parking. Increment the spline time. Once done parking, set state to park.
-            */
+            // Vehicle is on rails when parking. Increment the spline time. Once done parking, set state to park.
 
             *t += time.delta / TIME_TO_PARK;
 
@@ -175,7 +169,7 @@ fn state_update(
             }
         }
         VehicleState::Parked(spot) => {
-            /* Wait until it's time to start driving again, then set a route and unpark. */
+            // Wait until it's time to start driving again, then set a route and unpark.
             if it.has_ended(time.time) {
                 let mut lane = map.parking_to_drive(spot);
 

--- a/geom/src/polyline.rs
+++ b/geom/src/polyline.rs
@@ -92,7 +92,7 @@ impl PolyLine {
     /**
     Project p onto the polyline and return the distance squared from the projection to p
     **/
-    pub fn project_len2(&self, p: Vec2) -> f32 {
+    pub fn project_dist2(&self, p: Vec2) -> f32 {
         let proj = self.project(p);
         proj.distance2(p)
     }

--- a/geom/src/polyline.rs
+++ b/geom/src/polyline.rs
@@ -89,6 +89,17 @@ impl PolyLine {
         self.check_empty()
     }
 
+    /**
+    Project p onto the polyline and return the distance from the projection to p
+    **/
+    pub fn project_len(&self, p: Vec2) -> f32 {
+        let proj = self.project(p);
+        proj.distance2(p)
+    }
+
+    /**
+    Project p onto the polyline
+    **/
     pub fn project(&self, p: Vec2) -> Vec2 {
         self.project_segment(p).0
     }

--- a/geom/src/polyline.rs
+++ b/geom/src/polyline.rs
@@ -90,9 +90,9 @@ impl PolyLine {
     }
 
     /**
-    Project p onto the polyline and return the distance from the projection to p
+    Project p onto the polyline and return the distance squared from the projection to p
     **/
-    pub fn project_len(&self, p: Vec2) -> f32 {
+    pub fn project_len2(&self, p: Vec2) -> f32 {
         let proj = self.project(p);
         proj.distance2(p)
     }

--- a/wgpu-renderer/Cargo.toml
+++ b/wgpu-renderer/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 
-wgpu          = { version = "0.5.2"} 
+wgpu          = "0.5.2"
 futures       = { version = "0.3.4", default-features = false, features = ["executor"] }
 bytemuck      = "1.2.0"
 image         = { version = "0.23.4", default-features = false, features = ["png"] }

--- a/wgpu-renderer/Cargo.toml
+++ b/wgpu-renderer/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 
-wgpu          = "0.5.0"
+wgpu          = { version = "0.5.2"} 
 futures       = { version = "0.3.4", default-features = false, features = ["executor"] }
 bytemuck      = "1.2.0"
 image         = { version = "0.23.4", default-features = false, features = ["png"] }


### PR DESCRIPTION
Addresses issue #18 by using Itinerary to handle unparking. This means that collision detection logic isn't duplicated. Parking logic is not touched, because there is no risk of collision there.