### PR TITLE
Fix unsoundness in get_mut_pair

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -46,9 +46,9 @@ where
     K: std::fmt::Debug + Eq + std::hash::Hash,
 {
     unsafe {
-        assert_ne!(a, b, "`a` ({:?}) must not equal `b` ({:?})", a, b);
         let a = conns.get_mut(a)? as *mut _;
         let b = conns.get_mut(b)? as *mut _;
+        assert_ne!(a, b, "The two keys must not resolve to the same value");
         Some((&mut *a, &mut *b))
     }
 }


### PR DESCRIPTION
An unsoundness bug was found in a stackoverflow answer with code similar to the one in the `get_mut_pair` function. See the SO answer for more information about the problem: <https://stackoverflow.com/a/53146512/4159583>