### PR TITLE
Removing SPIRV_SHADER_PASSTHROUGH

### DIFF
--- a/wgpu_engine/src/gfx.rs
+++ b/wgpu_engine/src/gfx.rs
@@ -153,8 +153,7 @@ impl GfxContext {
             .request_device(
                 &wgpu::DeviceDescriptor {
                     label: None,
-                    features: wgpu::Features::ADDRESS_MODE_CLAMP_TO_BORDER
-                        | wgpu::Features::SPIRV_SHADER_PASSTHROUGH,
+                    features: wgpu::Features::ADDRESS_MODE_CLAMP_TO_BORDER,
                     limits: wgpu::Limits::default(),
                 },
                 None,


### PR DESCRIPTION
Removing SPIRV_SHADER_PASSTHROUGH wgpu feature requirement following @Uriopass comment on #59 . This fixes my issue on macOS.

Fixes #59