### PR TITLE
fixes two errors preventing repo from building w/default instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,6 @@ dependencies = [
  "common",
  "flat_spatial",
  "geom",
- "goria_version",
  "hecs",
  "imgui",
  "imgui-inspect",
@@ -921,10 +920,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "goria_version"
-version = "0.4.5"
-
-[[package]]
 name = "gpu-alloc"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,7 +982,6 @@ version = "0.1.0"
 dependencies = [
  "common",
  "egregoria",
- "goria_version",
  "log",
  "networking",
  "structopt",
@@ -1509,7 +1503,6 @@ dependencies = [
  "flat_spatial",
  "futures",
  "geom",
- "goria_version",
  "hecs",
  "imgui",
  "imgui-inspect",

--- a/egregoria/src/economy/market.rs
+++ b/egregoria/src/economy/market.rs
@@ -159,7 +159,8 @@ impl Market {
             let SingleMarket {
                 buy_orders,
                 sell_orders,
-                capital,
+                capital, 
+                ..
             } = market;
 
             all_trades.extend(

--- a/native_app/src/context.rs
+++ b/native_app/src/context.rs
@@ -51,7 +51,7 @@ impl Context {
                 size.width as f32 * 0.8,
                 size.height as f32 * 0.8,
             ))
-            .with_title(format!("Egregoria {}", goria_version::VERSION))
+            .with_title(format!("Egregoria {}", include_str!("../../VERSION")))
             .build(&el)
             .expect("Failed to create window");
 


### PR DESCRIPTION
(build also presently in errored state on github CI status badge).

this appears to be at least in part because of a recent commit (~5d) that changed versioning from using a cargo to a file.

the other error i'm not sure how/when it was introduced, i used rust's suggested fix.

here are errors to go along w/patches that fix them.  after applying, project builds and runs game as it's described on README.

```
   Compiling wgpu_engine v0.1.0 (/home/pracplayopen/work/src/Egregoria/wgpu_engine)
error[E0027]: pattern does not mention fields `ext_buy`, `ext_sell`
   --> egregoria/src/economy/market.rs:159:17
    |
159 |               let SingleMarket {
    |  _________________^
160 | |                 buy_orders,
161 | |                 sell_orders,
162 | |                 capital,
163 | |             } = market;
    | |_____________^ missing fields `ext_buy`, `ext_sell`
    |
help: include the missing fields in the pattern
    |
162 |                 capital, ext_buy, ext_sell } = market;
    |                        ~~~~~~~~~~~~~~~~~~~~~
help: if you don't care about these missing fields, you can explicitly ignore them
    |
162 |                 capital, .. } = market;
    |                        ~~~~~~

For more information about this error, try `rustc --explain E0027`.
error: could not compile `egregoria` due to previous error


------------------------------

   Compiling egregoria v0.1.0 (/home/pracplayopen/work/src/Egregoria/egregoria)
   Compiling native_app v0.4.3 (/home/pracplayopen/work/src/Egregoria/native_app)
error[E0433]: failed to resolve: use of undeclared crate or module `goria_version`
  --> native_app/src/context.rs:54:49
   |
54 |             .with_title(format!("Egregoria {}", goria_version::VERSION))
   |                                                 ^^^^^^^^^^^^^ use of undeclared crate or module `goria_version`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `native_app` due to previous error

```