### PR TITLE
Fix zooming on MacBook Pro touchpads

### DIFF
--- a/native_app/src/input.rs
+++ b/native_app/src/input.rs
@@ -62,11 +62,18 @@ impl InputContext {
                 };
                 true
             }
-            WindowEvent::MouseWheel {
-                delta: MouseScrollDelta::LineDelta(_, y),
-                ..
-            } => {
-                self.mouse.wheel_delta = *y;
+            WindowEvent::MouseWheel { delta, .. } => {
+                match delta {
+                    // Provided mainly by the scroll wheel of computer mouse devices
+                    MouseScrollDelta::LineDelta(_, y) => {
+                        self.mouse.wheel_delta = *y;
+                    }
+                    // Provided by touchpads and drawing tablets
+                    MouseScrollDelta::PixelDelta(pos) => {
+                        self.mouse.wheel_delta = pos.y as f32;
+                    }
+                }
+
                 true
             }
             _ => false,


### PR DESCRIPTION
Introduces MouseScrollDelta::PixelDelta variant to WindowEvent::MouseWheel handling.

Unfortunately, the way zoom is handled, I was unable to implement a more sensible sensitivity to the touchpad without digging into the input mapping system. Right now it's too sensitive compared to a mouse wheel, but better than not being able to zoom at all.