### PR TITLE
Lightening the edge of the water

### DIFF
--- a/assets/shaders/water.frag.wgsl
+++ b/assets/shaders/water.frag.wgsl
@@ -78,9 +78,14 @@ fn frag(@location(0) _in_tint: vec4<f32>,
     let reflected: vec3<f32> = reflect(-V, normal);
 
     let reflected_atmo = atmosphere(reflected, params.sun, 1e38);
-    let sun_contrib: f32 = clamp(dot(normal, params.sun), 0.0, 1.0);
 
-    let base_color: vec3<f32> = 0.03 * vec3<f32>(0.262, 0.396, 0.508);
+    let terrain_depth: f32 = 1.0 / textureLoad(t_depth, vec2<i32>(position.xy), 0).x;
+    let expected_depth: f32 = -dot(cam_to_wpos, params.cam_dir.xyz);
+    let water_depth = (expected_depth - terrain_depth) * params.cam_dir.z;
+    let relative_water_depth = clamp(water_depth / 32.0,0.0,1.0);
+
+    let base_factor = mix(0.03, 0.3, pow(1.0-relative_water_depth,4.0));
+    let base_color: vec3<f32> = base_factor * vec3<f32>(0.262, 0.396, 0.508);
     let sunpower: f32 = 0.1 * reflect_coeff;
 
     var final_rgb: vec3<f32> = base_color + sunpower * reflected_atmo;

--- a/engine/src/gfx.rs
+++ b/engine/src/gfx.rs
@@ -619,13 +619,6 @@ impl GfxContext {
             false => 1,
         };
 
-        if self.samples != samples {
-            self.samples = samples;
-            self.pipelines.write().unwrap().invalidate_all();
-            self.fbos = Self::create_textures(&self.device, &self.sc_desc, samples);
-            self.update_simplelit_bg();
-        }
-
         self.set_define_flag("FOG", settings.fog);
         self.set_define_flag("SSAO", settings.ssao);
         self.set_define_flag("TERRAIN_GRID", settings.terrain_grid);
@@ -633,6 +626,13 @@ impl GfxContext {
         self.set_define_flag("FOG_DEBUG", settings.fog_shader_debug);
         self.set_define_flag("PBR_ENABLED", settings.pbr_enabled);
         self.set_define_flag("MSAA", settings.msaa);
+
+        if self.samples != samples {
+            self.samples = samples;
+            self.pipelines.write().unwrap().invalidate_all();
+            self.fbos = Self::create_textures(&self.device, &self.sc_desc, samples);
+            self.update_simplelit_bg();
+        }
 
         self.settings = Some(settings);
     }


### PR DESCRIPTION
# Light Blue Coastlines
## Description
The coast line water looked dirty, because the sand texture was blended with the water, and apparently, the world ground at z ~ -32 has a different color.

This PR adds a light-blue shine to coasts, so they look tropical rather than dirty.

## Before this PR:
![image](https://github.com/Uriopass/Egregoria/assets/20659579/857aed0a-603d-4548-94cd-836187acd22b)

## After this PR:
![image](https://github.com/Uriopass/Egregoria/assets/20659579/e6a8d71a-72ac-4996-b046-7997a9415b93)


## Implementation explanation:
I wanted to lighten the coast, so I had to find out where the coast is. Luckily, the depth texture is already available to that shader, so you can calculate the depth difference between the geometry and the background. Then just multiply that by cam_dir.z, and you have the water depth.

## Remaining issues:
Please don't merge this yet, this doesn't work with MSAA yet.
![image](https://github.com/Uriopass/Egregoria/assets/20659579/5a9d8e19-7e31-4b2e-a683-ff2a693ca6cf)
I don't understand/know WGPU well enough yet to understand that error :/.